### PR TITLE
fix: add guard agains invalid m.top.session

### DIFF
--- a/components/BugsnagTask.brs
+++ b/components/BugsnagTask.brs
@@ -96,8 +96,10 @@ function notify(errorClass as string, errorMessage as string, severity as string
 		resolvedSeverity = severity
 	end if
 
-	' Only handled events are possible from brightscript so far
-	m.top.session.events.handled = m.top.session.events.handled + 1
+	if m.top.session <> invalid and m.top.session.events <> invalid
+		' Only handled events are possible from brightscript so far
+		m.top.session.events.handled = m.top.session.events.handled + 1
+	end if
 
 	event["session"] = m.top.session
 	event["severity"] = resolvedSeverity


### PR DESCRIPTION
This MR fixes #3.

Added a simple guard before accessing m.top.session field and incrementing a number of handled events.

By looking at the code, this shouldn't happen, as the `startSession` is called at the very beginning of the task start. Wouldn't bet on it, but maybe an error happened while the bugsnag task was still initializing.