### PR TITLE
refactor: http handling logic

### DIFF
--- a/components/BugsnagTask.brs
+++ b/components/BugsnagTask.brs
@@ -155,7 +155,9 @@ function notify(errorClass as string, errorMessage as string, severity as string
 
 	if m.top.session <> invalid and m.top.session.events <> invalid
 		' Only handled events are possible from brightscript so far
-		m.top.session.events.handled = m.top.session.events.handled + 1
+		session = m.top.session
+		session.events.handled = session.events.handled + 1
+		m.top.session = session
 	end if
 
 	event["session"] = m.top.session
@@ -200,13 +202,16 @@ end function
 
 function createDevicePayload()
 	deviceInfo = getDeviceInfo()
+	uiResolution = m.deviceInfo.GetUIResolution()
 
 	device = {
-		locale: deviceInfo.GetCurrentLocale(),
 		connection: deviceInfo.GetConnectionType(),
+		generalMemoryLevel: deviceInfo.GetGeneralMemoryLevel(),
+		locale: deviceInfo.GetCurrentLocale(),
 		model: deviceInfo.GetModel(),
 		time: getNowISO(),
 		tts: getAudioGuideStatusAsString()
+		uiResolution: uiResolution.height.ToStr() + "x" + uiResolution.width.ToStr()
 	}
 
 	if m.top.reportChannelClientId
@@ -328,24 +333,6 @@ function handleHTTPResponse(event)
 
 		m.jobs.Delete(identity.toStr())
 	end if
-end function
-
-'***************
-' @desc Creates a response model
-' @param Object
-' @return Object ContentNode'
-'***************
-function createResponseModel(response as object, identityId = invalid) as object
-	responseModel = CreateObject("roSGNode", "ResponseModel")
-	responseModel.errorStatus = response.error
-	responseModel.code = response.code
-	responseModel.data = response.data
-	responseModel.msg = response.msg
-	responseModel.request = response.request
-
-	if identityId <> invalid then responseModel.identityId = identityId
-
-	return responseModel
 end function
 
 function logNetworkError(error as object)

--- a/components/BugsnagTask.xml
+++ b/components/BugsnagTask.xml
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component name="BugsnagTask" extends="Task" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://devtools.web.roku.com/schema/RokuSceneGraph.xsd">
 	<interface>
-		<field id="releaseStage" type="string" />
-		<field id="appVersion" type="string" />
-		<field id="apiKey" type="string" />
-		<field id="user" type="assocarray" />
+		<field id="releaseStage" type="String" />
+		<field id="appVersion" type="String" />
+		<field id="apiKey" type="String" />
+		<field id="user" type="AssocArray" />
 
-		<field id="reportChannelClientId" type="bool" value="true" />
-		<field id="useIpAsUserId" type="bool" value="true" />
+		<field id="reportChannelClientId" type="Boolean" value="true" />
+		<field id="useIpAsUserId" type="Boolean" value="true" />
+		<field id="enableHttpLogs" type="Boolean" value="false" />
 
-		<field id="reqRepo" type="assocarray" />
-		<field id="request" type="assocarray" />
-		<field id="response" type="node" />
-		<field id="deleteReqReference" type="string" />
-		<field id="logNetworkErrors" type="boolean" value="false" />
-
-		<field id="session" type="assocarray" />
+		<field id="session" type="AssocArray" />
 
 		<function name="bugsnagroku_notify" />
 		<function name="bugsnagroku_leaveBreadcrumb" />


### PR DESCRIPTION
This PR closes #4, by removing all ResponseModel related logic, as well as simplifying the HTTP response handler. Now, it's only going to be used if the `enableHttpLogs` field is toggled to true.

I've refactored a few other things, mostly minor changes:
	- modified how `m.top.session` is modified, as changing AssocArray on m.top is without effect, it's immutable.
	- added `memoryLevel` and `uiResolution` to `createDevicePayload`, as it can be useful for debugging some issues on the low-end devices
	- added `logNetworkResponse` function for logging Bugsnag response if needed
	- renamed `logNetworkErrors` to `enableHttpLogs` as it's logging both errors and responses now
	- deleted unused fields from the bugsnagTask.xml