### PR TITLE
refactor: change notify func signature and implement handing for exceptions arr

### DIFF
--- a/components/BugsnagTask.brs
+++ b/components/BugsnagTask.brs
@@ -118,7 +118,20 @@ function leaveBreadcrumb(name as string, breadcrumbType as string, metaData = {}
 	m.breadcrumbs.Push(breadcrumb)
 end function
 
-function notify(errorClass as string, errorMessage as string, severity as string, context as string, metaData as object)
+' /**
+'  * notify: Notifies the Bugsnag API that an error(s) has happened, and leaves an error breadcrumb
+'  *
+'  * @param {errorClass as string, errorMessage as string, severity as string, context as string, exceptions as object, metaData as object} errorInfo
+'  * @return {Dynamic}
+'  */
+function notify(errorInfo as object)
+	errorClass = errorInfo.errorClass
+	errorMessage = errorInfo.errorMessage
+	severity = errorInfo.severity
+	context = errorInfo.context
+	exceptions = errorInfo.exceptions
+	metaData = errorInfo.metaData
+
 	data = {
 		events: [],
 		notifier: m.notifier
@@ -135,12 +148,16 @@ function notify(errorClass as string, errorMessage as string, severity as string
 		event["context"] = context
 	end if
 
-	exception = {
-		message: errorMessage,
-		stacktrace: []
-	}
-	exception["errorClass"] = errorClass
-	event["exceptions"] = [exception]
+	if exceptions <> invalid
+		event["exceptions"] = exceptions
+	else
+		exception = {
+			message: errorMessage,
+			stacktrace: []
+		}
+		exception["errorClass"] = errorClass
+		event["exceptions"] = [exception]
+	end if
 
 	if (metadata <> invalid)
 		event["metaData"] = metaData

--- a/package.json
+++ b/package.json
@@ -1,31 +1,31 @@
 {
-  "name": "bugsnag-roku",
-  "version": "1.0.0",
-  "description": "Bugsnag library for Roku",
-  "main": "index.js",
-  "scripts": {
-    "release": "standard-version",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/redboxllc/bugsnag-roku.git"
-  },
-  "keywords": [
-    "ropm",
-    "roku",
-    "bugsnag"
-  ],
-  "authors": [
-    "Miloš Rašić <milos.rasic@redbox.com>"
-  ],
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/redboxllc/bugsnag-roku/issues"
-  },
-  "homepage": "https://github.com/redboxllc/bugsnag-roku#readme",
-  "devDependencies": {
-    "standard-version": "^9.0.0"
-  },
-  "dependencies": {}
+	"name": "bugsnag-roku",
+	"version": "1.0.0",
+	"description": "Bugsnag library for Roku",
+	"main": "index.js",
+	"scripts": {
+		"release": "standard-version",
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/redboxllc/bugsnag-roku.git"
+	},
+	"keywords": [
+		"ropm",
+		"roku",
+		"bugsnag"
+	],
+	"authors": [
+		"Miloš Rašić <milos.rasic@redbox.com>"
+	],
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/redboxllc/bugsnag-roku/issues"
+	},
+	"homepage": "https://github.com/redboxllc/bugsnag-roku#readme",
+	"devDependencies": {
+		"standard-version": "^9.0.0"
+	},
+	"dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
 		"roku",
 		"bugsnag"
 	],
-	"authors": [
-		"Miloš Rašić <milos.rasic@redbox.com>"
+	"author": "Miloš Rašić <milos.rasic@redbox.com>",
+	"contributors": [
+		"Darko Tasevski <darko.tasevski@redbox.com>"
 	],
 	"license": "Apache-2.0",
 	"bugs": {


### PR DESCRIPTION
This MR changes the signature of the `notify` function, as the Roku devices seem to be crashing when more than 5 arguments are provided to the `callFunc`. With new changes, all previous args are a part of the new `errorInfo` argument, and there is a new `exceptions` argument included.

I've also refactored logic around `exceptions` handling, and we're now using the `exceptions` array if provided, and creating one from scratch only if there are no exceptions passed via arg.

Also, I've updated package.json's list of contributors 🙃 
