### PR TITLE
fix: move notify observer to the main Task loop

### DIFF
--- a/components/BugsnagTask.brs
+++ b/components/BugsnagTask.brs
@@ -45,11 +45,19 @@ end function
 function startTask()
 	startSession()
 
+	m.top.observeFieldScoped("notify", m.port)
+
 	while (true)
 		event = Wait(0, m.port)
 		eventType = Type(event)
 		if eventType = "roUrlEvent"
 			handleHTTPResponse(event)
+		else if eventType = "roSGNodeEvent"
+			field = event.GetField()
+			if field = "notify"
+				eventData = event.GetData()
+				notify(eventData)
+			end if
 		end if
 	end while
 end function
@@ -124,9 +132,7 @@ end function
 '  * @param {errorClass as string, errorMessage as string, severity as string, context as string, exceptions as object, metaData as object} errorInfo
 '  * @return {Dynamic}
 '  */
-function notify(event as object)
-	errorInfo = event.getData()
-
+function notify(errorInfo as object)
 	errorClass = errorInfo.errorClass
 	errorMessage = errorInfo.errorMessage
 	severity = errorInfo.severity

--- a/components/BugsnagTask.xml
+++ b/components/BugsnagTask.xml
@@ -6,7 +6,7 @@
 		<field id="apiKey" type="String" />
 		<field id="user" type="AssocArray" />
 
-		<field id="notify" type="AssocArray" onChange="bugsnagroku_notify" />
+		<field id="notify" type="AssocArray" />
 
 		<field id="reportChannelClientId" type="Boolean" value="true" />
 		<field id="useIpAsUserId" type="Boolean" value="true" />


### PR DESCRIPTION
This MR fixes the handling of the `notify` field. Because we had a regular observer on this field before, the code inside the observer callback is executed on the render thread. To execute the callback inside the Task thread we must observe the field via port inside the Task's main loop.