### PR TITLE
fix: Use cross firmware friendly function for getting device version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.0.0](https://github.com/redboxllc/bugsnag-roku/compare/v3.0.0...v4.0.0) (2021-03-16)
+
+
+### ⚠ BREAKING CHANGES
+
+* this changes BugsnagTask's API, as we're not using function anymore in order to make sure that all code is being executed on the Task thread
+
+* remove function fields and replace them as AA fields ([2f4a1a7](https://github.com/redboxllc/bugsnag-roku/commit/2f4a1a7dacce7ed5383831f835300c907e9432c3))
+
 ## [3.0.0](https://github.com/redboxllc/bugsnag-roku/compare/v2.0.0...v3.0.0) (2021-02-17)
 
 

--- a/components/BugsnagTask.brs
+++ b/components/BugsnagTask.brs
@@ -243,7 +243,11 @@ function createDevicePayload()
 		device["deviceId"] = deviceInfo.GetChannelClientId()
 	end if
 
-	device["firmwareVersion"] = deviceInfo.GetOSVersion()
+	if FindMemberFunction(deviceInfo, "GetOSVersion") <> invalid
+		device["firmwareVersion"] = deviceInfo.GetOSVersion()
+	else 
+		device["firmwareVersion"] = deviceInfo.GetVersion()
+	end if
 
 	return device
 end function

--- a/components/BugsnagTask.brs
+++ b/components/BugsnagTask.brs
@@ -246,7 +246,13 @@ function createDevicePayload()
 	if FindMemberFunction(deviceInfo, "GetOSVersion") <> invalid
 		device["firmwareVersion"] = deviceInfo.GetOSVersion()
 	else 
-		device["firmwareVersion"] = deviceInfo.GetVersion()
+		version = deviceInfo.GetVersion()
+		device["firmwareVersion"] = {
+			major: Val(version.mid(2, 1))
+			minor: Val(version.mid(4, 2))
+			revision: "n/a"
+			build: Val(version.mid(8, 4))
+		}
 	end if
 
 	return device

--- a/components/BugsnagTask.brs
+++ b/components/BugsnagTask.brs
@@ -254,12 +254,13 @@ function createDevicePayload()
 	if FindMemberFunction(deviceInfo, "GetOSVersion") <> invalid
 		device["firmwareVersion"] = deviceInfo.GetOSVersion()
 	else 
+		' Example version: 034.08E01185A
 		version = deviceInfo.GetVersion()
 		device["firmwareVersion"] = {
-			major: Val(version.mid(2, 1))
-			minor: Val(version.mid(4, 2))
-			revision: "n/a"
-			build: Val(version.mid(8, 4))
+			major: Val(version.mid(2, 1)) ' From example, character 4
+			minor: Val(version.mid(4, 1)) ' From example, character 0
+			revision: Val(version.mid(5, 1)) ' From example, character 8
+			build: Val(version.mid(8, 4)) ' From example, characters 1185
 		}
 	end if
 

--- a/components/BugsnagTask.xml
+++ b/components/BugsnagTask.xml
@@ -7,15 +7,14 @@
 		<field id="user" type="AssocArray" />
 
 		<field id="notify" type="AssocArray" />
+		<field id="leaveBreadcrumb" type="AssocArray" />
+		<field id="updateUser" type="AssocArray" />
 
 		<field id="reportChannelClientId" type="Boolean" value="true" />
 		<field id="useIpAsUserId" type="Boolean" value="true" />
 		<field id="enableHttpLogs" type="Boolean" value="false" />
 
 		<field id="session" type="AssocArray" />
-
-		<function name="bugsnagroku_leaveBreadcrumb" />
-		<function name="bugsnagroku_updateUser" />
 	</interface>
 
 	<script type="text/brightscript" uri="pkg:/components/BugsnagTask.brs" />

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 	],
 	"author": "Miloš Rašić <milos.rasic@redbox.com>",
 	"contributors": [
-		"Darko Tasevski <darko.tasevski@redbox.com>"
+		"Darko Tasevski <darko.tasevski@redbox.com>",
+		"Igor Perzic <igor.perzic@redbox.com>"
 	],
 	"license": "Apache-2.0",
 	"bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bugsnag-roku",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"description": "Bugsnag library for Roku",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
The originally used [`GetOSVersion`](https://developer.roku.com/en-ca/docs/references/brightscript/interfaces/ifdeviceinfo.md#getosversion-as-object) was added only in 9.2 firmware version