### PR TITLE
refactor: remove function fields and replace them as AA fields

### DIFF
--- a/components/BugsnagTask.xml
+++ b/components/BugsnagTask.xml
@@ -7,15 +7,14 @@
 		<field id="user" type="AssocArray" />
 
 		<field id="notify" type="AssocArray" />
+		<field id="leaveBreadcrumb" type="AssocArray" />
+		<field id="updateUser" type="AssocArray" />
 
 		<field id="reportChannelClientId" type="Boolean" value="true" />
 		<field id="useIpAsUserId" type="Boolean" value="true" />
 		<field id="enableHttpLogs" type="Boolean" value="false" />
 
 		<field id="session" type="AssocArray" />
-
-		<function name="bugsnagroku_leaveBreadcrumb" />
-		<function name="bugsnagroku_updateUser" />
 	</interface>
 
 	<script type="text/brightscript" uri="pkg:/components/BugsnagTask.brs" />


### PR DESCRIPTION
This MR is removing the rest of the functional fields and replaces them with simple AA fields that have listeners inside the task's loop.

This was done to avoid situations where we have some data on the render thread and some data on the task thread, which was being used on both threads, but because of different scopes, it was out of sync. By moving all logic to the Task's `runFunction` `while` loop, all logic is going to be executed on the task thread.

-----

TLDR: This is a BREAKING CHANGE as this changes BugsnagTask's API, as we're not using the function anymore in order to make sure that all code is being executed on the Task thread.