### PR TITLE
fix: runFunction name for BugsnagTask

### DIFF
--- a/components/BugsnagTask.brs
+++ b/components/BugsnagTask.brs
@@ -1,6 +1,6 @@
 function init()
 	m.top.id = "BugsnagTask"
-	m.top.functionName = "bugsnagroku_startTask"
+	m.top.functionName = "startTask"
 
 	m.port = CreateObject("roMessagePort")
 	m.top.observeFieldScoped("notify", m.port)
@@ -253,7 +253,7 @@ function createDevicePayload()
 
 	if FindMemberFunction(deviceInfo, "GetOSVersion") <> invalid
 		device["firmwareVersion"] = deviceInfo.GetOSVersion()
-	else 
+	else
 		' Example version: 034.08E01185A
 		version = deviceInfo.GetVersion()
 		device["firmwareVersion"] = {


### PR DESCRIPTION
This MR fixes the name initialization for BugsnagTask `runFunction`. 

There was a [breaking change](https://rokudevelopers.slack.com/archives/C0182DU8BT8/p1613668267018700) in `ropm` for prefixing the runFunction field values. So the current logic we have in the bugsnag-roku is not working, because when transpiled we end up with `functionName:"bugsnagroku_bugsnagroku_startTask"` instead of `functionName:"bugsnagroku_startTask"`